### PR TITLE
production環境でRDTをOFF

### DIFF
--- a/src/redux/app/store.ts
+++ b/src/redux/app/store.ts
@@ -37,7 +37,7 @@ const reducer = {
 
 export const store = configureStore({
   reducer,
-  devTools: false,
+  devTools: process.env.NODE_ENV === 'development',
 })
 
 export type AppDispatch = typeof store.dispatch

--- a/src/redux/app/store.ts
+++ b/src/redux/app/store.ts
@@ -37,6 +37,7 @@ const reducer = {
 
 export const store = configureStore({
   reducer,
+  devTools: false,
 })
 
 export type AppDispatch = typeof store.dispatch


### PR DESCRIPTION
## 実装内容
- production環境でReduxDevToolsを開くと、dev環境同様にSliceの内容が見えてしまっていた
部分を見えないように設定