### PR TITLE
商品ページのカードレイアウトが崩れていた部分を修正

### DIFF
--- a/src/components/layout/HomeLayout.tsx
+++ b/src/components/layout/HomeLayout.tsx
@@ -69,7 +69,7 @@ const HomeLayout: FC<Props> = (props) => {
         </span>
         {children}
       </main>
-      <footer className="flex h-12 w-full items-center justify-center border-t ">
+      <footer className="sticky bottom-0 flex h-10 w-full items-center justify-center border-t border-white bg-gray-200">
         {/* FIXME: 文字色を修正 */}
         <a
           className="flex items-center text-black"

--- a/src/components/modules/MenuCard.tsx
+++ b/src/components/modules/MenuCard.tsx
@@ -9,18 +9,18 @@ const MenuCard: FC = () => {
   const menueListSelector = useAppSelector(selectMenueList)
 
   return (
-    <ul className="flex flex-row flex-wrap justify-center">
+    <ul className="flex flex-wrap ">
       {menueListSelector.map((item, index) => (
         <li
           key={index}
           className="
-          mx-2 mt-4
-          flex
-          w-full
-          max-w-[40vw]
+          m-[calc(20px/2)] flex w-[calc(100%/2_-_20px)]
           flex-col
-          rounded-md bg-gray-200 p-2
+          rounded-md bg-gray-200
+          p-2
           text-sm
+          shadow-md sm:m-[calc(40px/2)]
+          sm:w-[calc(100%/3_-_40px)]
           "
         >
           {/* // TODO: カード毎のデザインはここのclassNameを修正する */}

--- a/src/components/pages/HomePageBase.tsx
+++ b/src/components/pages/HomePageBase.tsx
@@ -1,7 +1,9 @@
 import React, { FC } from 'react'
 import { useRouter } from 'next/router'
+import Image from 'next/image'
 // NOTE: original
 import { HomeLayout } from '../../components/layout'
+import { ImageLoader } from '../../lib'
 // NOTE: Redux関連
 import { useAppDispatch } from '../../redux/app/hooks'
 import { selectStep, changeState } from '../../redux/features/step/stepSlice'
@@ -19,23 +21,33 @@ const HomePageBase: FC = () => {
   return (
     <HomeLayout title="ようこそ">
       <p className="m-24"></p>
-      <h1 className="font-cursive justify-center font-light text-black">
+      <h1 className="font-cursive items-center justify-center font-light text-black">
         <span className="block text-5xl">b l o o m</span>
       </h1>
-      <div className="m-32 flex w-full justify-center">
-        <button className="absolute  mt-44   px-5  py-5" onClick={registClick}>
+      <div
+        className="
+        mt-auto mb-10
+        flex w-full
+        justify-center
+        bg-gray-200
+        "
+      >
+        <button
+          className="rounded-full bg-white p-2 shadow-lg"
+          onClick={registClick}
+        >
           <svg
             xmlns="http://www.w3.org/2000/svg"
             className="h-12 w-12"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
-            stroke-width="1"
+            stroke-width="2"
           >
             <path
               stroke-linecap="round"
               stroke-linejoin="round"
-              d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z"
+              d="M13 7l5 5m0 0l-5 5m5-5H6"
             />
           </svg>
         </button>

--- a/src/components/pages/MenuBase.tsx
+++ b/src/components/pages/MenuBase.tsx
@@ -67,28 +67,35 @@ const MenuBase = () => {
 
   return (
     <HomeLayout title="商品一覧">
-      <div className="flex flex-row justify-center">
-        <MenuCard />
-      </div>
-      <button
-        className=" absolute bottom-[70px]  px-5 py-1 "
-        onClick={clientClick}
+      <MenuCard />
+      <div
+        className="
+        sticky
+        bottom-10 ml-auto mr-4
+        flex flex-row
+        p-2
+        "
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          className="h-12 w-12"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          stroke-width="1"
+        <button
+          className="rounded-full bg-white p-2 shadow-lg"
+          onClick={clientClick}
         >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z"
-          />
-        </svg>
-      </button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-12 w-12"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M13 7l5 5m0 0l-5 5m5-5H6"
+            />
+          </svg>
+        </button>
+      </div>
       <CartDetailModal />
     </HomeLayout>
   )


### PR DESCRIPTION
## 実装内容
- トップページとメニューページをそれぞれ修正

![image](https://user-images.githubusercontent.com/71167689/175763495-229a83e3-03fa-4c26-adad-81a2c9217db1.png)

![image](https://user-images.githubusercontent.com/71167689/175763514-f7c2c6b6-bebc-4efe-9bbe-0319754fa832.png)
